### PR TITLE
Fix type manipulators reading stale class schema before UpdateClass

### DIFF
--- a/mypy/semanal_main.py
+++ b/mypy/semanal_main.py
@@ -94,12 +94,20 @@ def semantic_analysis_for_scc(graph: Graph, scc: list[str], errors: Errors) -> N
     The scc will be processed roughly in the order the modules are included
     in the list.
     """
+    from mypy.typelevel import typelevel_ctx
+
     patches: Patches = []
     # Note that functions can't define new module-level attributes
     # using 'global x', since module top levels are fully processed
     # before functions. This limitation is unlikely to go away soon.
-    process_top_levels(graph, scc, patches)
-    process_functions(graph, scc, patches)
+    #
+    # Defer type-level reads of class member schemas here: class transformations
+    # such as UpdateClass are only applied below in apply_class_plugin_hooks, so
+    # any type-level computation forced during these passes must not observe the
+    # stale pre-transformation schema (see typelevel.defer_class_schema).
+    with typelevel_ctx.defer_class_schema():
+        process_top_levels(graph, scc, patches)
+        process_functions(graph, scc, patches)
     # We use patch callbacks to fix up things when we expect relatively few
     # callbacks to be required.
     apply_semantic_analyzer_patches(patches)
@@ -150,19 +158,24 @@ def semantic_analysis_for_targets(
     defined on self) removed by AST stripper that may need to be reintroduced
     here.  They must be added before any methods are analyzed.
     """
+    from mypy.typelevel import typelevel_ctx
+
     patches: Patches = []
-    if any(isinstance(n.node, MypyFile) for n in nodes):
-        # Process module top level first (if needed).
-        process_top_levels(graph, [state.id], patches)
-    restore_saved_attrs(saved_attrs)
-    analyzer = state.manager.semantic_analyzer
-    for n in nodes:
-        if isinstance(n.node, MypyFile):
-            # Already done above.
-            continue
-        process_top_level_function(
-            analyzer, state, state.id, n.node.fullname, n.node, n.active_typeinfo, patches
-        )
+    # Defer type-level reads of class member schemas until UpdateClass and other
+    # class transformations are applied below (mirrors semantic_analysis_for_scc).
+    with typelevel_ctx.defer_class_schema():
+        if any(isinstance(n.node, MypyFile) for n in nodes):
+            # Process module top level first (if needed).
+            process_top_levels(graph, [state.id], patches)
+        restore_saved_attrs(saved_attrs)
+        analyzer = state.manager.semantic_analyzer
+        for n in nodes:
+            if isinstance(n.node, MypyFile):
+                # Already done above.
+                continue
+            process_top_level_function(
+                analyzer, state, state.id, n.node.fullname, n.node, n.active_typeinfo, patches
+            )
     apply_semantic_analyzer_patches(patches)
     apply_class_plugin_hooks(graph, [state.id], state.manager.errors)
     check_type_arguments_in_targets(nodes, state, state.manager.errors)

--- a/mypy/typelevel.py
+++ b/mypy/typelevel.py
@@ -32,7 +32,9 @@ from mypy.nodes import (
     Block,
     ClassDef,
     Context,
+    Decorator,
     FuncDef,
+    RefExpr,
     SymbolTable,
     SymbolTableNode,
     TypeInfo,
@@ -90,6 +92,10 @@ class TypeLevelContext:
         # ourselves or something instead?
         self._evaluator: TypeLevelEvaluator | None = None
         self._suppress_errors: bool = False
+        # True while the main semantic-analysis passes (module top levels and
+        # function bodies) are running, before class transformations such as
+        # UpdateClass have been applied. See defer_class_schema() below.
+        self._defer_class_schema: bool = False
 
     @property
     def api(self) -> SemanticAnalyzerInterface | None:
@@ -125,6 +131,29 @@ class TypeLevelContext:
             yield
         finally:
             self._suppress_errors = saved
+
+    @contextmanager
+    def defer_class_schema(self) -> Iterator[None]:
+        """Defer type-level reads of class member schemas during semantic analysis.
+
+        Class transformations such as UpdateClass are applied in a dedicated
+        pass (apply_class_plugin_hooks) that runs *after* the main semantic
+        analysis passes which resolve annotations and type aliases. Those
+        earlier passes can nonetheless force evaluation of type-level
+        computations (e.g. via has_placeholder() or annotation analysis).
+
+        While this context is active, reading the member schema of a class that
+        is subject to a not-yet-applied UpdateClass effect raises
+        EvaluationStuck, so the surrounding computation stays unevaluated (and
+        is retried later, once the schema is final) instead of observing the
+        stale pre-transformation schema and emitting spurious errors.
+        """
+        saved = self._defer_class_schema
+        self._defer_class_schema = True
+        try:
+            yield
+        finally:
+            self._defer_class_schema = saved
 
 
 # Global context instance for type-level computation
@@ -1002,6 +1031,45 @@ def _should_skip_type_info(type_info: TypeInfo, api: SemanticAnalyzerInterface) 
     return False
 
 
+def _returns_update_class(func_type: CallableType | None) -> bool:
+    """Whether a callable's return type is an (unevaluated) UpdateClass[...]."""
+    if func_type is None:
+        return False
+    ret_type = func_type.ret_type
+    # Don't use get_proper_type here - it would eagerly expand the operator.
+    return isinstance(ret_type, TypeOperatorType) and ret_type.type.name == "UpdateClass"
+
+
+def _update_class_func_type(node: object) -> CallableType | None:
+    """Extract the CallableType of a (possibly decorated) function definition."""
+    if isinstance(node, Decorator):
+        node = node.func
+    if isinstance(node, FuncDef) and isinstance(node.type, CallableType):
+        return node.type
+    return None
+
+
+def _class_has_pending_update_class(info: TypeInfo) -> bool:
+    """Whether `info` is (or will be) transformed by an UpdateClass effect.
+
+    Mirrors the detection in semanal_main._apply_update_class_effects: a class
+    is a target of UpdateClass if a class decorator returns UpdateClass, or if
+    an __init_subclass__ in one of its base classes returns UpdateClass.
+
+    Used together with typelevel_ctx._defer_class_schema to hold off reading a
+    class's member schema until the transformation has actually been applied.
+    """
+    for decorator in info.defn.decorators:
+        if isinstance(decorator, RefExpr) and decorator.node is not None:
+            if _returns_update_class(_update_class_func_type(decorator.node)):
+                return True
+    for base in info.mro[1:]:
+        sym = base.names.get("__init_subclass__")
+        if sym is not None and _returns_update_class(_update_class_func_type(sym.node)):
+            return True
+    return False
+
+
 def _get_members_dict(
     target_arg: Type, *, evaluator: TypeLevelEvaluator, attrs_only: bool
 ) -> dict[str, Type]:
@@ -1023,6 +1091,12 @@ def _get_members_dict(
 
     if not isinstance(target, Instance):
         return {}
+
+    if typelevel_ctx._defer_class_schema and _class_has_pending_update_class(target.type):
+        # This class will be transformed by an UpdateClass effect that has not
+        # been applied yet. Stay unevaluated so we retry once the schema is
+        # final, rather than reading the stale pre-transformation schema.
+        raise EvaluationStuck
 
     members: dict[str, Type] = {}
 

--- a/test-data/unit/check-typelevel-update-class.test
+++ b/test-data/unit/check-typelevel-update-class.test
@@ -64,3 +64,47 @@ reveal_type(Child().x)  # N: Revealed type is "builtins.int"
 
 [builtins fixtures/typelevel.pyi]
 [typing fixtures/typing-full.pyi]
+
+
+[case testUpdateClassTypeManipulatorSeesUpdatedSchema]
+# flags: --python-version 3.14
+from typing import Any, Literal, Member, UpdateClass, IsAssignable, Bool, RaiseError, GetMemberType
+
+class CustomField[T]: ...
+
+class WrapFields:
+    def __init_subclass__[T](cls: type[T]) -> UpdateClass[
+        Member[Literal["x"], CustomField[int]],
+    ]:
+        ...
+
+class Point(WrapFields):
+    x: int
+
+# The UpdateClass transformation rewrites x: int into x: CustomField[int].
+reveal_type(Point.x)  # N: Revealed type is "__main__.CustomField[builtins.int]"
+
+type IsCustomField[C, N] = (
+    Bool[Literal[True]]
+    if IsAssignable[GetMemberType[C, N], CustomField[Any]]
+    else RaiseError[Literal["Field is not a CustomField!"]]
+)
+
+# A type manipulator that reads Point's schema must observe the *transformed*
+# schema (CustomField[int]), not the stale pre-transformation schema (int).
+# Otherwise a spurious "Field is not a CustomField!" error is emitted, because
+# annotation analysis forces evaluation before UpdateClass has been applied.
+def uses_annotation() -> None:
+    foo: IsCustomField[Point, Literal["x"]]
+    reveal_type(foo)  # N: Revealed type is "Literal[True]"
+
+# Regression: the same must hold for a function-local type alias. Its target
+# was previously evaluated (and frozen to Never) during semantic analysis,
+# before the UpdateClass transformation had been applied.
+def uses_local_alias() -> None:
+    type XL = IsCustomField[Point, Literal["x"]]
+    xl: XL
+    reveal_type(xl)  # N: Revealed type is "Literal[True]"
+
+[builtins fixtures/typelevel.pyi]
+[typing fixtures/typing-full.pyi]


### PR DESCRIPTION
I found problem with `typing.UpdateClass` in this fork: the `RaiseError` typemap continue to raise errors, as there was no any transformations. 

```python
class CustomField[T]:
    pass


class WrapFields:
    def __init_subclass__[T](
        cls: type[T],
    ) -> typing.UpdateClass[
        *[
            typing.Member[x.name, CustomField[x.type]]
            for x in typing.Iter[typing.Attrs[T]]
        ]
    ]:
        return None  # type: ignore[return-value]


class Point(WrapFields):
    x: int   # UpdateClass rewrites this to CustomField[int]

type IsCustomField[C, N] = (
    Bool[Literal[True]]
    if IsAssignable[GetMemberType[C, N], CustomField[Any]]
    else RaiseError[Literal["Field is not a CustomField!"]]
)

reveal_type(IsCustomField[x]) # reveals CustomField[int] but still fire the error!
```

i asked claude to fix this and it seems to work